### PR TITLE
Add system of logging contexts and verbosity

### DIFF
--- a/cooler/__init__.py
+++ b/cooler/__init__.py
@@ -10,6 +10,7 @@ A cool place to store your Hi-C.
 
 """
 from ._version import __version__, __format_version__
+from ._logging import get_verbosity_level, set_verbosity_level
 from .api import Cooler, annotate
 from .create import create_cooler, rename_chroms, create_scool
 from .reduce import merge_coolers, coarsen_cooler, zoomify_cooler

--- a/cooler/_logging.py
+++ b/cooler/_logging.py
@@ -1,11 +1,171 @@
 import logging
+import sys
 
+_logging_context = None
 _loggers = {}
 
+verbosity_to_loglevel = {
+    -3: logging.NOTSET,
+    -2: logging.CRITICAL,
+    -1: logging.ERROR,
+    0: logging.WARNING,
+    1: logging.INFO,
+    2: logging.DEBUG,
+}
 
-def get_logger(name="cooler"):
+loglevel_to_verbosity = {
+    logging.NOTSET: -3,
+    logging.CRITICAL: -2,
+    logging.ERROR: -1,
+    logging.WARNING: 0,
+    logging.INFO: 1,
+    logging.DEBUG: 2,
+}
+
+
+def configure(
+    logger,
+    stream=None,
+    filename=None,
+    open_kws=None,
+    handlers=None,
+    level=logging.WARNING,
+    format="{levelname}:{name}:{message}",
+    datefmt="%Y-%m-%d %I:%M:%S %p",
+    style="{",
+    propagate=False,
+):
+    """
+    Configure a logger for a stream or file or a custom set of handlers.
+
+    Based on `logging.basicConfig` but works on any logger, not just the root one.
+
+    Parameters
+    ----------
+    logger : :class:`logging.Logger`
+        A logger.
+    stream : file-like, optional
+        A stream, like ``sys.stdout``.
+    filename : str, optional
+        Path to a file, instead of a stream.
+    open_kws : dict, optionsl
+        Keyword args to ``open`` if using a filename instead of a stream.
+        Defaults to using mode='a' and for text streams: encoding='utf-8' and
+        errors='backslashreplace'.
+    handlers : sequence of logging Handlers
+        Arbitrary logging handlers to register. Cannot be used with ``filename``
+        or ``stream``.
+    level : int, optional
+        The log level.
+    format : str, optional
+        A format string for log records.
+    datefmt : str, optional
+        A format string for the ``asctime`` variable when used in log records.
+    style : {"{", "$", "%"}, optional
+        The templating style of the log record format string.
+    propagate : bool, optional
+        Whether the logger should propagate log records up to its parent.
+
+    Notes
+    -----
+    Any of the logger's existing handlers will be closed and destroyed.
+
+    For logging level values, see
+    https://docs.python.org/3/howto/logging.html#logging-levels
+
+    For a list of variables that can go into log records, see
+    https://docs.python.org/3/library/logging.html#logrecord-attributes
+
+    """
+    if handlers is None:
+        if stream is not None and filename is not None:
+            raise ValueError("'stream' and 'filename' should not be specified together")
+    else:
+        if stream is not None or filename is not None:
+            raise ValueError(
+                "'stream' or 'filename' should not be specified together with 'handlers'"
+            )
+
+    # Set up the new handlers
+    if filename is not None:
+        open_kws = {} if open_kws is None else open_kws
+        open_kws.setdefault("mode", "a")
+        if "b" in open_kws["mode"]:
+            open_kws["encoding"] = None
+            open_kws["errors"] = None
+        else:
+            open_kws.setdefault("encoding", "utf-8")
+            open_kws.setdefault("errors", "backslashreplace")
+        handlers = [logging.FileHandler(filename, **open_kws)]
+    elif stream is not None:
+        handlers = [logging.StreamHandler(stream)]
+
+    # Wipe out the old handlers
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+        handler.close()
+
+    # Set up the formatter and register it on all new handlers
+    formatter = logging.Formatter(format, datefmt, style)
+    for handler in handlers:
+        if handler.formatter is None:
+            handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    if level is not None:
+        logger.setLevel(level)
+
+    logger.propagate = propagate
+
+
+def set_logging_context(ctx):  # use this in cooler cli
+    global _logging_context
+
+    logger = logging.getLogger("cooler")
+
+    if _logging_context != ctx:
+        if ctx == "lib":
+            configure(logger, stream=sys.stdout, level=logging.WARNING, format="{message}")
+            logging.captureWarnings(False)
+        elif ctx == "cli":
+            configure(logger, stream=sys.stderr, level=logging.INFO)
+            logging.captureWarnings(True)
+        elif ctx == "none":
+            for handler in logger.handlers[:]:
+                logger.removeHandler(handler)
+                handler.close()
+            logging.captureWarnings(False)
+        else:
+            raise ValueError("Unknown logging context: '{}'".format(ctx))
+        _logging_context = ctx
+
+
+def get_logging_context():
+    return _logging_context
+
+
+def set_verbosity_level(level):  # export this
+    logger = logging.getLogger("cooler")
+    try:
+        loglevel = verbosity_to_loglevel[level]
+    except KeyError:
+        raise ValueError(
+            "Verbosity level must be one of: -2, -1, 0, 1, 2; got '{}'.".format(level)
+        )
+    logger.setLevel(verbosity_to_loglevel[level])
+
+
+def get_verbosity_level():
+    logger = logging.getLogger("cooler")
+    return loglevel_to_verbosity[logger.level]
+
+
+def get_logger(name="cooler"):  # export this
     # Based on ipython traitlets
-    global _loggers
+    global _loggers, _logging_context
+
+    if _logging_context is None:
+        set_logging_context("lib")
 
     if name not in _loggers:
         _loggers[name] = logging.getLogger(name)

--- a/cooler/cli/__init__.py
+++ b/cooler/cli/__init__.py
@@ -1,8 +1,9 @@
 import logging
 import sys
 from .._version import __version__
-from .._logging import get_logger
+from .._logging import get_logger, set_logging_context, set_verbosity_level
 import click
+
 
 # Monkey patch
 click.core._verify_python3_env = lambda: None
@@ -31,63 +32,56 @@ def cli(verbose, debug):
     Type -h or --help after any subcommand for more information.
 
     """
-    # Initialize logging to stderr
-    logging.basicConfig(stream=sys.stderr)
-    logging.captureWarnings(True)
-    root_logger = get_logger()
+    set_logging_context("cli")
+    set_verbosity_level(verbose + 1)
+    logger = get_logger()
 
-    # Set verbosity level
-    if verbose > 0:
-        root_logger.setLevel(logging.DEBUG)
-        if verbose > 1:  # pragma: no cover
-            try:
-                import psutil
-                import atexit
+    if verbose > 1:  # pragma: no cover
+        try:
+            import psutil
+            import atexit
 
-                @atexit.register
-                def process_dump_at_exit():
-                    process_attrs = [
-                        "cmdline",
-                        # 'connections',
-                        "cpu_affinity",
-                        "cpu_num",
-                        "cpu_percent",
-                        "cpu_times",
-                        "create_time",
-                        "cwd",
-                        # 'environ',
-                        "exe",
-                        # 'gids',
-                        "io_counters",
-                        "ionice",
-                        "memory_full_info",
-                        # 'memory_info',
-                        # 'memory_maps',
-                        "memory_percent",
-                        "name",
-                        "nice",
-                        "num_ctx_switches",
-                        "num_fds",
-                        "num_threads",
-                        "open_files",
-                        "pid",
-                        "ppid",
-                        "status",
-                        "terminal",
-                        "threads",
-                        # 'uids',
-                        "username",
-                    ]
-                    p = psutil.Process()
-                    info_ = p.as_dict(process_attrs, ad_value="")
-                    for key in process_attrs:
-                        root_logger.debug("PSINFO:'{}': {}".format(key, info_[key]))
+            @atexit.register
+            def process_dump_at_exit():
+                process_attrs = [
+                    "cmdline",
+                    # 'connections',
+                    "cpu_affinity",
+                    "cpu_num",
+                    "cpu_percent",
+                    "cpu_times",
+                    "create_time",
+                    "cwd",
+                    # 'environ',
+                    "exe",
+                    # 'gids',
+                    "io_counters",
+                    "ionice",
+                    "memory_full_info",
+                    # 'memory_info',
+                    # 'memory_maps',
+                    "memory_percent",
+                    "name",
+                    "nice",
+                    "num_ctx_switches",
+                    "num_fds",
+                    "num_threads",
+                    "open_files",
+                    "pid",
+                    "ppid",
+                    "status",
+                    "terminal",
+                    "threads",
+                    # 'uids',
+                    "username",
+                ]
+                p = psutil.Process()
+                info_ = p.as_dict(process_attrs, ad_value="")
+                for key in process_attrs:
+                    logger.debug("PSINFO:'{}': {}".format(key, info_[key]))
 
-            except ImportError:
-                root_logger.warning("Install psutil to see process information.")
-
-    else:
-        root_logger.setLevel(logging.INFO)
+        except ImportError:
+            logger.warning("Install psutil to see process information.")
 
     # Set hook for postmortem debugging
     if debug:  # pragma: no cover


### PR DESCRIPTION
Provides two "contexts" for handling all log messages depending on the entry point (libary vs commandline). We also translate the logging module's levels into more intuitive verbosity levels.

Why not just use `print` in library functions? 
* CLI should normally print warnings and messages to stderr and reserve stdout for real output.
* Why write custom verbosity logic for different functions when a standard exists (warning, info, debug).
* Ability to change the printing behavior without changing any code.

### Contexts
`lib`
* Prints to stdout
* Prints just the messages without extra log metadata
* Verbosity level  = 0 (log level WARNING)

`cli`
* Prints to stderr
* Prints more elaborate log records
* Verbosity level = 1 (log level INFO)

### Verbosity levels
* 0 -> equivalent to WARNING. Print `logger.warning` messages and more severe (error).
* 1 -> equivalent to INFO. Print `logger.info`, `logger.warning` and more severe.
* 2 -> equivalent to DEBUG. Print `logger.debug`, `logger.info`, `logger.warning` and more severe.

There is also -1 (ERROR) which could be implemented as a `--quiet` mode.
The global verbosity level is exposed through `cooler.get_verbosity_level()` and `set_verbosity_level()`.

### Application development

New loggers used inside cooler should be obtained using `get_logger(__name__)` or `get_logger("cooler")` instead of using `logging.getLogger`. This is to instantiate them correctly with "null handlers". 

As per behavior of the logging system, child loggers propagate their messages to their parent, so only the top level logger (called "cooler") needs to be configured. The "cooler" logger itself has `propagate=False` so that records don't bubble up to Python's root logger.

### Configuration

The logging module has a million ways to configure a logger and they all suck, especially if you want to reconfigure existing loggers. I took the best implementation [logging.basicConfig](https://github.com/python/cpython/blob/3.9/Lib/logging/__init__.py#L1904) and re-wrote it to work on any logger (not just the root logger) with better defaults so that the "cooler" package logger can be easily configured and re-configured.

### Drawbacks

Because of how importing works, when running the CLI, the logging context will first get set to "lib" and later get reset to "cli" once the cli entry point function gets invoked.

Verbosity is a global parameter, but there is little getting around that if we use the logging system. On the other hand, it isn't such a bad idea at all.