### PR TITLE
Fix TypeError when reading a .cool file with uint bin ids

### DIFF
--- a/cooler/api.py
+++ b/cooler/api.py
@@ -575,7 +575,7 @@ def annotate(pixels, bins, replace=False):
         if len(bins) > len(pixels):
             bin1 = pixels["bin1_id"]
             lo = bin1.min()
-            hi = bin1.max() + 1
+            hi = bin1.max() + bin1.dtype.type(1)
             lo = 0 if np.isnan(lo) else lo
             hi = 0 if np.isnan(hi) else hi
             right = bins[lo:hi]
@@ -588,7 +588,7 @@ def annotate(pixels, bins, replace=False):
         if len(bins) > len(pixels):
             bin2 = pixels["bin2_id"]
             lo = bin2.min()
-            hi = bin2.max() + 1
+            hi = bin2.max() + bin2.dtype.type(1)
             lo = 0 if np.isnan(lo) else lo
             hi = 0 if np.isnan(hi) else hi
             right = bins[lo:hi]

--- a/cooler/cli/dump.py
+++ b/cooler/cli/dump.py
@@ -59,7 +59,7 @@ class CSRReader(object):
         if (i1 - i0 > 0) or (j1 - j0 > 0):
 
             # coarsegrain the offsets to extract a big chunk of rows at a time
-            offsets = self.offset_selector[i0 : i1 + 1]
+            offsets = self.offset_selector[i0 : i1 + i1.dtype.type(1)]
             which_offsets = _prune_partition(offsets, chunksize)
 
             for o0, o1 in zip(which_offsets[:-1], which_offsets[1:]):

--- a/cooler/core.py
+++ b/cooler/core.py
@@ -202,8 +202,8 @@ def _region_to_extent(h5, chrom_ids, region, binsize):
         chrom_lo = h5["indexes"]["chrom_offset"][cid]
         chrom_hi = h5["indexes"]["chrom_offset"][cid + 1]
         chrom_bins = h5["bins"]["start"][chrom_lo:chrom_hi]
-        yield chrom_lo + np.searchsorted(chrom_bins, start, "right") - 1
-        yield chrom_lo + np.searchsorted(chrom_bins, end, "left")
+        yield chrom_lo + chrom_lo.dtype.type(np.searchsorted(chrom_bins, start, "right") - 1)
+        yield chrom_lo + chrom_lo.dtype.type(np.searchsorted(chrom_bins, end, "left"))
 
 
 def region_to_offset(h5, chrom_ids, region, binsize=None):
@@ -238,7 +238,7 @@ class CSRReader(object):
 
     def index_col(self, i0, i1, j0, j1):
         """Retrieve pixel table row IDs corresponding to query rectangle."""
-        edges = self.h5["indexes"]["bin1_offset"][i0 : i1 + 1]
+        edges = self.h5["indexes"]["bin1_offset"][i0 : i1 + i1.dtype.type(1)]
         index = []
         for lo1, hi1 in zip(edges[:-1], edges[1:]):
             if hi1 - lo1 > 0:
@@ -257,7 +257,7 @@ class CSRReader(object):
 
         i, j, v = [], [], []
         if (i1 - i0 > 0) or (j1 - j0 > 0):
-            edges = h5["indexes"]["bin1_offset"][i0 : i1 + 1]
+            edges = h5["indexes"]["bin1_offset"][i0 : i1 + i1.dtype.type(1)]
             data = h5["pixels"][field]
             p0, p1 = edges[0], edges[-1]
 


### PR DESCRIPTION
Workaround TypeError exception raised by `cooler.annotate()` when bin ids in `/pixels` table are stored as unsigned integers.

The exception is due to the implicit conversion to `float` performed by numpy when adding 1 (of type `int`) to an `np.uint` e.g. here:
https://github.com/open2c/cooler/blob/987e87dd357c99a0a070b8a25cb7aaef86f1655c/cooler/api.py#L575-L580

https://github.com/open2c/cooler/blob/987e87dd357c99a0a070b8a25cb7aaef86f1655c/cooler/api.py#L588-L594

See https://github.com/numpy/numpy/issues/3118 for more details.

The conversion to `float` causes the `_validate_indexer()` method from pandas to raise, because `key.stop` is now a `float`.

<details>
  <summary>Traceback</summary>

```txt
Traceback (most recent call last):
  File "/tmp/cooler/venv/bin/cooler", line 8, in <module>
    sys.exit(cli())
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/tmp/cooler/venv/lib/python3.10/site-packages/cooler/cli/_util.py", line 200, in decorated
    func(*args, **kwargs)
  File "/tmp/cooler/venv/lib/python3.10/site-packages/cooler/cli/dump.py", line 434, in dump
    for chunk in chunks:
  File "/tmp/cooler/venv/lib/python3.10/site-packages/cooler/cli/dump.py", line 191, in annotator
    chunk = api.annotate(chunk, bins[["chrom", "start", "end"]], replace=True)
  File "/tmp/cooler/venv/lib/python3.10/site-packages/cooler/api.py", line 581, in annotate
    right = bins[lo:hi]
  File "/usr/lib/python3.10/site-packages/pandas/core/frame.py", line 3477, in __getitem__
    indexer = convert_to_index_sliceable(self, key)
  File "/usr/lib/python3.10/site-packages/pandas/core/indexing.py", line 2324, in convert_to_index_sliceable
    return idx._convert_slice_indexer(key, kind="getitem")
  File "/usr/lib/python3.10/site-packages/pandas/core/indexes/numeric.py", line 279, in _convert_slice_indexer
    return super()._convert_slice_indexer(key, kind=kind)
  File "/usr/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 4042, in _convert_slice_indexer
    self._validate_indexer("slice", key.stop, "getitem")
  File "/usr/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 6308, in _validate_indexer
    raise self._invalid_indexer(form, key)
TypeError: cannot do slice indexing on Int64Index with these indexers [26386.0] of type float64
```
</details>

This behavior can be reproduced by running `cooler dump --join` on this file: [cooler_test_file_uint.cool.gz](https://github.com/open2c/cooler/files/9212967/cooler_test_file_uint.cool.gz)