### PR TITLE
Update cooler show to work with matplotlib 3.6+

### DIFF
--- a/cooler/cli/show.py
+++ b/cooler/cli/show.py
@@ -227,7 +227,7 @@ def show(
         sys.exit(1)
 
     plt.figure(figsize=(11, 10))
-    plt.gcf().canvas.set_window_title("Contact matrix".format())
+    plt.get_current_fig_manager().set_window_title("Contact matrix".format())
     plt.title("")
     plt.imshow(
         load_matrix(c, row_region, col_region, field, balanced, scale),


### PR DESCRIPTION
`FigureCanvas.set_window_title()` was [deprecated](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.4.0.html#backend-deprecations)  in matplotlib 3.4.0 and [removed](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.6.0.html#classes-methods-and-attributes) in 3.6.0.

This PR updates `cooler show` to use `plt.get_current_fig_manager()` instead of `plt.gcf().canvas.set_window_title` to set the plot window title.