### PR TITLE
Update util.py to work with NumPy 1.24+

### DIFF
--- a/cooler/util.py
+++ b/cooler/util.py
@@ -687,7 +687,7 @@ def infer_meta(x, index=None):  # pragma: no cover
 
 
 def get_meta(
-    columns, dtype=None, index_columns=None, index_names=None, default_dtype=np.object
+    columns, dtype=None, index_columns=None, index_names=None, default_dtype=np.object_
 ):  # pragma: no cover
     """
     Extracted and modified from pandas/io/parsers.py :


### PR DESCRIPTION
NumPy 1.20 [deprecated](https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations) several dtype aliases like `np.int`. These aliases have been removed with NumPy 1.24.0 (see last bullet point under "Expired Deprecations" [here](https://github.com/numpy/numpy/releases/tag/v1.24.0)).

`cooler/util.py` references `np.object`, which is no longer available.

https://github.com/open2c/cooler/blob/987e87dd357c99a0a070b8a25cb7aaef86f1655c/cooler/util.py#L689-L692

This leads to errors like the following:
```
cooler --help
/usr/local/lib/python3.10/dist-packages/cooler/util.py:690: FutureWarning: In the future `np.object` will be defined as the corresponding NumPy scalar.  (This may have returned Python scalars in past versions.
  columns, dtype=None, index_columns=None, index_names=None, default_dtype=np.object
Traceback (most recent call last):
  File "/usr/local/bin/cooler", line 5, in <module>
    from cooler.cli import cli
  File "/usr/local/lib/python3.10/dist-packages/cooler/__init__.py", line 14, in <module>
    from .api import Cooler, annotate
  File "/usr/local/lib/python3.10/dist-packages/cooler/api.py", line 22, in <module>
    from .util import parse_cooler_uri, parse_region, open_hdf5, closing_hdf5
  File "/usr/local/lib/python3.10/dist-packages/cooler/util.py", line 690, in <module>
    columns, dtype=None, index_columns=None, index_names=None, default_dtype=np.object
  File "/usr/local/lib/python3.10/dist-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'object'. Did you mean: 'object_'?

```

This PR replaces `np.object` with `np.object_`.

The [docs](https://numpy.org/doc/1.24/reference/arrays.dtypes.html#specifying-and-constructing-data-types) seem to suggest that this is the same as using Python's built-in `object` type.

I decided to stick with `np.object_` because I a not familiar enough with `cooler` library to know whether using built-in types could cause issue with older versions of Python/NumPy.