### PR TITLE
Improve handling of uint attributes

### DIFF
--- a/cooler/balance.py
+++ b/cooler/balance.py
@@ -337,7 +337,7 @@ def balance_cooler(
 
     """
     # Divide the number of elements into non-overlapping chunks
-    nnz = clr.info["nnz"]
+    nnz = int(clr.info["nnz"])
     if chunksize is None:
         chunksize = nnz
         spans = [(0, nnz)]
@@ -353,7 +353,7 @@ def balance_cooler(
         base_filters.append(partial(_zero_diags, ignore_diags))
 
     # Initialize the bias weights
-    n_bins = clr.info["nbins"]
+    n_bins = int(clr.info["nbins"])
     if x0 is not None:
         bias = x0
         bias[np.isnan(bias)] = 0

--- a/cooler/cli/cload.py
+++ b/cooler/cli/cload.py
@@ -547,7 +547,7 @@ def pairs(bins, pairs_path, cool_path, metadata, assembly, chunksize,
         f_in = sys.stdin
         _, f_in = get_header(f_in)
     elif int(_pandas_version[0]) > 0:
-        if int(_pandas_version[1]) < 2:
+        if int(_pandas_version[0]) < 2:
             f_in = get_handle(pairs_path, mode='r', compression='infer')[0]
         else:
             f_in = get_handle(pairs_path, mode='r', compression='infer').handle

--- a/cooler/cli/show.py
+++ b/cooler/cli/show.py
@@ -100,7 +100,7 @@ def interactive(ax, c, row_chrom, col_chrom, field, balanced, scale):  # pragma:
         im.set_extent(extent)
         ax.figure.canvas.draw_idle()
 
-    binsize = c.info["bin-size"]
+    binsize = int(c.info["bin-size"])
     row_chrom_len = c.chromsizes[row_chrom]
     col_chrom_len = c.chromsizes[col_chrom]
     plotstate = {"placeholders": [], "prev_extent": get_extent(plt.gca())}

--- a/cooler/parallel.py
+++ b/cooler/parallel.py
@@ -268,5 +268,5 @@ class chunkgetter:
 
 def split(clr, map=map, chunksize=10_000_000, spans=None, **kwargs):
     if spans is None:
-        spans = partition(0, clr.info["nnz"], chunksize)
+        spans = partition(0, int(clr.info["nnz"]), chunksize)
     return MultiplexDataPipe(chunkgetter(clr, **kwargs), spans, map)


### PR DESCRIPTION
Fix various TypeErrors occurring when handling uint attributes (e.g. `nnz`, `nbins` or `bin_size`).
The errors are caused by the implicit conversion to float when dividing Python `int` by `np.uint*`.

See https://github.com/open2c/cooler/pull/284 and https://github.com/numpy/numpy/issues/3118 for more details.