### PR TITLE
Make annotate faster by using indexing instead of merge

### DIFF
--- a/src/cooler/api.py
+++ b/src/cooler/api.py
@@ -591,39 +591,43 @@ def annotate(pixels, bins, replace=False):
     # indexing - they can easily get cast to float and cause problems.
     anns = []
 
+    # Select bin annotations that correspond to the bin1 IDs in the pixels df
     if "bin1_id" in columns:
         bin1 = pixels["bin1_id"].to_numpy().astype(int)
-        if len(bins) > len(pixels):
-            lo = bin1.min(initial=0)
-            hi = bin1.max(initial=0)
-            lo = 0 if np.isnan(lo) else int(lo)
-            hi = 0 if np.isnan(hi) else int(hi)
-            ann1 = _slice(bins, lo, hi)
-        else:
-            lo = 0
-            ann1 = _slice(bins, lo, None)
-        # Select bin annotations that correspond to the bin1 IDs in pixels
-        ann1 = ann1.iloc[bin1 - lo]
-        anns.append(
-            ann1.rename(columns=lambda x: x + "1").reset_index(drop=True)
-        )
+        if len(bin1) > 0:
+            ann1 = _slice(bins, 0, 0)
+            if len(bins) > len(pixels):
+                lo = bin1.min()
+                hi = bin1.max()
+                lo = 0 if np.isnan(lo) else int(lo)
+                hi = 0 if np.isnan(hi) else int(hi)
+                ann1 = _slice(bins, lo, hi)
+            else:
+                lo = 0
+                ann1 = _slice(bins, lo, None)
+            ann1 = ann1.iloc[bin1 - lo]
+            anns.append(
+                ann1.rename(columns=lambda x: x + "1").reset_index(drop=True)
+            )
 
+    # Select bin annotations that correspond to the bin2 IDs in the pixels df
     if "bin2_id" in columns:
         bin2 = pixels["bin2_id"].to_numpy().astype(int)
-        if len(bins) > len(pixels):
-            lo = bin2.min(initial=0)
-            hi = bin2.max(initial=0)
-            lo = 0 if np.isnan(lo) else int(lo)
-            hi = 0 if np.isnan(hi) else int(hi)
-            ann2 = _slice(bins, lo, hi)
-        else:
-            lo = 0
-            ann2 = _slice(bins, lo, None)
-        # Select bin annotations that correspond to the bin2 IDs in pixels
-        ann2 = ann2.iloc[bin2 - lo]
-        anns.append(
-            ann2.rename(columns=lambda x: x + "2").reset_index(drop=True)
-        )
+        if len(bin2) > 0:
+            ann2 = _slice(bins, 0, 0)
+            if len(bins) > len(pixels):
+                lo = bin2.min()
+                hi = bin2.max()
+                lo = 0 if np.isnan(lo) else int(lo)
+                hi = 0 if np.isnan(hi) else int(hi)
+                ann2 = _slice(bins, lo, hi)
+            else:
+                lo = 0
+                ann2 = _slice(bins, lo, None)
+            ann2 = ann2.iloc[bin2 - lo]
+            anns.append(
+                ann2.rename(columns=lambda x: x + "2").reset_index(drop=True)
+            )
 
     # Drop original bin IDs if not wanted
     if replace:

--- a/src/cooler/api.py
+++ b/src/cooler/api.py
@@ -576,7 +576,7 @@ def annotate(pixels, bins, replace=False):
     :py:class:`DataFrame`
     """
     columns = pixels.columns
-    
+
     if isinstance(bins, RangeSelector1D):
         def _slice(sel, lo, hi):
             # slicing a selector is exclusive like iloc
@@ -587,10 +587,10 @@ def annotate(pixels, bins, replace=False):
             return df.loc[lo:hi]
 
     # Extract the required bin ranges from the bin table.
-    # NOTE: Bin IDs in the pixel table may be uint. Avoid using these for 
+    # NOTE: Bin IDs in the pixel table may be uint. Avoid using these for
     # indexing - they can easily get cast to float and cause problems.
     anns = []
-    
+
     if "bin1_id" in columns:
         bin1 = pixels["bin1_id"].to_numpy().astype(int)
         if len(bins) > len(pixels):
@@ -607,7 +607,7 @@ def annotate(pixels, bins, replace=False):
         anns.append(
             ann1.rename(columns=lambda x: x + "1").reset_index(drop=True)
         )
-    
+
     if "bin2_id" in columns:
         bin2 = pixels["bin2_id"].to_numpy().astype(int)
         if len(bins) > len(pixels):
@@ -624,12 +624,12 @@ def annotate(pixels, bins, replace=False):
         anns.append(
             ann2.rename(columns=lambda x: x + "2").reset_index(drop=True)
         )
-        
+
     # Drop original bin IDs if not wanted
     if replace:
         cols_to_drop = [col for col in ("bin1_id", "bin2_id") if col in columns]
         pixels = pixels.drop(cols_to_drop, axis=1)
-    
+
     # Concatenate bin annotations with pixels
     out = pd.concat([*anns, pixels.reset_index(drop=True)], axis=1)
     out.index = pixels.index

--- a/src/cooler/api.py
+++ b/src/cooler/api.py
@@ -592,15 +592,19 @@ def annotate(pixels, bins, replace=False):
             lo = 0 if np.isnan(lo) else lo
             hi = 0 if np.isnan(hi) else hi
             if is_selector:
-                right = bins[lo:hi + bin1.dtype.type(1)]  # slicing works like iloc
+                right1 = bins[lo:hi + bin1.dtype.type(1)]  # slicing works like iloc
             else:
-                right = bins.loc[lo:hi]
+                right1 = bins.loc[lo:hi]
         elif is_selector:
-            right = bins[:]
+            right1 = bins[:]
+            lo = 0
         else:
-            right = bins
-
-        pixels = pixels.merge(right, how="left", left_on="bin1_id", right_index=True)
+            right1 = bins
+            lo = 0
+        right1.columns = [f'{col}1' for col in right1.columns]
+        right1 = right1.iloc[pixels['bin1_id']-lo].reset_index(drop=True)
+    else:
+        right1 = None
 
     if "bin2_id" in columns:
         if len(bins) > len(pixels):
@@ -610,18 +614,23 @@ def annotate(pixels, bins, replace=False):
             lo = 0 if np.isnan(lo) else lo
             hi = 0 if np.isnan(hi) else hi
             if is_selector:
-                right = bins[lo:hi + bin2.dtype.type(1)]  # slicing works like iloc
+                right2 = bins[lo:hi + bin2.dtype.type(1)]  # slicing works like iloc
             else:
-                right = bins.loc[lo:hi]
+                right2 = bins.loc[lo:hi]
         elif is_selector:
-            right = bins[:]
+            right2 = bins[:]
+            lo = 0
         else:
-            right = bins
-
-        pixels = pixels.merge(
-            right, how="left", left_on="bin2_id", right_index=True, suffixes=("1", "2")
-        )
-
+            right2 = bins
+            lo = 0
+        right2.columns = [f'{col}2' for col in right2.columns]
+        right2 = right2.iloc[pixels['bin2_id']-lo].reset_index(drop=True)
+    else:
+        right2 = None
+    index = pixels.index
+    pixels = pd.concat([pixels.reset_index(drop=True), right1, right2],
+                        axis=1)
+    pixels.index = index
     # rearrange columns
     pixels = pixels[list(pixels.columns[ncols:]) + list(pixels.columns[:ncols])]
 

--- a/src/cooler/api.py
+++ b/src/cooler/api.py
@@ -582,7 +582,7 @@ def annotate(pixels, bins, replace=False):
     """
     columns = pixels.columns
     ncols = len(columns)
-    is_selector = isinstance(bins, cooler.core.RangeSelector1D)
+    is_selector = isinstance(bins, RangeSelector1D)
 
     if "bin1_id" in columns:
         if len(bins) > len(pixels):

--- a/src/cooler/api.py
+++ b/src/cooler/api.py
@@ -596,18 +596,15 @@ def annotate(pixels, bins, replace=False):
     if "bin1_id" in columns:
         bin1 = pixels["bin1_id"].to_numpy().astype(int, copy=False, casting="safe")
         if len(bin1) == 0:
-            min = max = 0
+            bmin = bmax = 0
         elif len(bins) > len(pixels):
-            min = bin1.min()
-            max = bin1.max()
-            min = 0 if np.isnan(min) else int(min)
-            max = 0 if np.isnan(min) else int(max)
+            bmin, bmax = bin1.min(), bin1.max()
         else:
-            min, max = 0, None
-        ann1 = _loc_slice(bins, min, max)
+            bmin, bmax = 0, None
+        ann1 = _loc_slice(bins, bmin, bmax)
         anns.append(
             ann1
-            .iloc[bin1 - min]
+            .iloc[bin1 - bmin]
             .rename(columns=lambda x: x + "1")
             .reset_index(drop=True)
         )
@@ -616,18 +613,15 @@ def annotate(pixels, bins, replace=False):
     if "bin2_id" in columns:
         bin2 = pixels["bin2_id"].to_numpy().astype(int, copy=False, casting="safe")
         if len(bin2) == 0:
-            min = max = 0
+            bmin = bmax = 0
         elif len(bins) > len(pixels):
-            min = bin2.min()
-            max = bin2.max()
-            min = 0 if np.isnan(min) else int(min)
-            max = 0 if np.isnan(max) else int(max)
+            bmin, bmax = bin2.min(), bin2.max()
         else:
-            min, max = 0, None
-        ann2 = _loc_slice(bins, min, max)
+            bmin, bmax = 0, None
+        ann2 = _loc_slice(bins, bmin, bmax)
         anns.append(
             ann2
-            .iloc[bin2 - min]
+            .iloc[bin2 - bmin]
             .rename(columns=lambda x: x + "2")
             .reset_index(drop=True)
         )

--- a/src/cooler/api.py
+++ b/src/cooler/api.py
@@ -594,10 +594,10 @@ def annotate(pixels, bins, replace=False):
     if "bin1_id" in columns:
         bin1 = pixels["bin1_id"].to_numpy().astype(int)
         if len(bins) > len(pixels):
-            lo = int(bin1.min())
-            hi = int(bin1.max())
-            lo = 0 if np.isnan(lo) else lo
-            hi = 0 if np.isnan(hi) else hi
+            lo = bin1.min()
+            hi = bin1.max()
+            lo = 0 if np.isnan(lo) else int(lo)
+            hi = 0 if np.isnan(hi) else int(hi)
             ann1 = _slice(bins, lo, hi)
         else:
             lo = 0
@@ -611,10 +611,10 @@ def annotate(pixels, bins, replace=False):
     if "bin2_id" in columns:
         bin2 = pixels["bin2_id"].to_numpy().astype(int)
         if len(bins) > len(pixels):
-            lo = int(bin2.min())
-            hi = int(bin2.max())
-            lo = 0 if np.isnan(lo) else lo
-            hi = 0 if np.isnan(hi) else hi
+            lo = bin2.min()
+            hi = bin2.max()
+            lo = 0 if np.isnan(lo) else int(lo)
+            hi = 0 if np.isnan(hi) else int(hi)
             ann2 = _slice(bins, lo, hi)
         else:
             lo = 0

--- a/src/cooler/api.py
+++ b/src/cooler/api.py
@@ -594,8 +594,8 @@ def annotate(pixels, bins, replace=False):
     if "bin1_id" in columns:
         bin1 = pixels["bin1_id"].to_numpy().astype(int)
         if len(bins) > len(pixels):
-            lo = bin1.min()
-            hi = bin1.max()
+            lo = bin1.min(initial=0)
+            hi = bin1.max(initial=0)
             lo = 0 if np.isnan(lo) else int(lo)
             hi = 0 if np.isnan(hi) else int(hi)
             ann1 = _slice(bins, lo, hi)
@@ -611,8 +611,8 @@ def annotate(pixels, bins, replace=False):
     if "bin2_id" in columns:
         bin2 = pixels["bin2_id"].to_numpy().astype(int)
         if len(bins) > len(pixels):
-            lo = bin2.min()
-            hi = bin2.max()
+            lo = bin2.min(initial=0)
+            hi = bin2.max(initial=0)
             lo = 0 if np.isnan(lo) else int(lo)
             hi = 0 if np.isnan(hi) else int(hi)
             ann2 = _slice(bins, lo, hi)

--- a/src/cooler/api.py
+++ b/src/cooler/api.py
@@ -582,7 +582,7 @@ def annotate(pixels, bins, replace=False):
     """
     columns = pixels.columns
     ncols = len(columns)
-    is_selector = isinstance(bins, RangeSelector1D)
+    is_selector = isinstance(bins, cooler.core.RangeSelector1D)
 
     if "bin1_id" in columns:
         if len(bins) > len(pixels):
@@ -592,14 +592,14 @@ def annotate(pixels, bins, replace=False):
             lo = 0 if np.isnan(lo) else lo
             hi = 0 if np.isnan(hi) else hi
             if is_selector:
-                right1 = bins[lo:hi + bin1.dtype.type(1)]  # slicing works like iloc
+                right1 = bins[lo:hi + bin1.dtype.type(1)].copy()  # slicing works like iloc
             else:
-                right1 = bins.loc[lo:hi]
+                right1 = bins.loc[lo:hi].copy()
         elif is_selector:
-            right1 = bins[:]
+            right1 = bins[:].copy()
             lo = 0
         else:
-            right1 = bins
+            right1 = bins.copy()
             lo = 0
         right1.columns = [f'{col}1' for col in right1.columns]
         right1 = right1.iloc[pixels['bin1_id']-lo].reset_index(drop=True)
@@ -614,14 +614,14 @@ def annotate(pixels, bins, replace=False):
             lo = 0 if np.isnan(lo) else lo
             hi = 0 if np.isnan(hi) else hi
             if is_selector:
-                right2 = bins[lo:hi + bin2.dtype.type(1)]  # slicing works like iloc
+                right2 = bins[lo:hi + bin2.dtype.type(1)].copy()  # slicing works like iloc
             else:
-                right2 = bins.loc[lo:hi]
+                right2 = bins.loc[lo:hi].copy()
         elif is_selector:
-            right2 = bins[:]
+            right2 = bins[:].copy()
             lo = 0
         else:
-            right2 = bins
+            right2 = bins.copy()
             lo = 0
         right2.columns = [f'{col}2' for col in right2.columns]
         right2 = right2.iloc[pixels['bin2_id']-lo].reset_index(drop=True)

--- a/src/cooler/api.py
+++ b/src/cooler/api.py
@@ -116,7 +116,7 @@ class Cooler:
             return dict(grp[path].attrs)
 
     def open(self, mode="r", **kwargs):
-        """ Open the HDF5 group containing the Cooler with :py:mod:`h5py`
+        """Open the HDF5 group containing the Cooler with :py:mod:`h5py`
 
         Functions as a context manager. Any ``open_kws`` passed during
         construction are ignored.
@@ -145,21 +145,21 @@ class Cooler:
 
     @property
     def binsize(self):
-        """ Resolution in base pairs if uniform else None """
+        """Resolution in base pairs if uniform else None"""
         return self._info["bin-size"]
 
     @property
     def chromsizes(self):
-        """ Ordered mapping of reference sequences to their lengths in bp """
+        """Ordered mapping of reference sequences to their lengths in bp"""
         return self._chromsizes
 
     @property
     def chromnames(self):
-        """ List of reference sequence names """
+        """List of reference sequence names"""
         return list(self._chromsizes.index)
 
     def offset(self, region):
-        """ Bin ID containing the left end of a genomic region
+        """Bin ID containing the left end of a genomic region
 
         Parameters
         ----------
@@ -182,11 +182,11 @@ class Cooler:
                 grp,
                 self._chromids,
                 parse_region(region, self._chromsizes),
-                self.binsize
+                self.binsize,
             )
 
     def extent(self, region):
-        """ Bin IDs containing the left and right ends of a genomic region
+        """Bin IDs containing the left and right ends of a genomic region
 
         Parameters
         ----------
@@ -209,12 +209,12 @@ class Cooler:
                 grp,
                 self._chromids,
                 parse_region(region, self._chromsizes),
-                self.binsize
+                self.binsize,
             )
 
     @property
     def info(self):
-        """ File information and metadata
+        """File information and metadata
 
         Returns
         -------
@@ -230,7 +230,7 @@ class Cooler:
         return (self._info["nbins"],) * 2
 
     def chroms(self, **kwargs):
-        """ Chromosome table selector
+        """Chromosome table selector
 
         Returns
         -------
@@ -246,7 +246,7 @@ class Cooler:
         return RangeSelector1D(None, _slice, None, self._info["nchroms"])
 
     def bins(self, **kwargs):
-        """ Bin table selector
+        """Bin table selector
 
         Returns
         -------
@@ -272,7 +272,7 @@ class Cooler:
         return RangeSelector1D(None, _slice, _fetch, self._info["nbins"])
 
     def pixels(self, join=False, **kwargs):
-        """ Pixel table selector
+        """Pixel table selector
 
         Parameters
         ----------
@@ -317,7 +317,7 @@ class Cooler:
         divisive_weights=None,
         chunksize=10000000,
     ):
-        """ Contact matrix selector
+        """Contact matrix selector
 
         Parameters
         ----------
@@ -391,12 +391,8 @@ class Cooler:
                     region2 = region
                 region1 = parse_region(region, self._chromsizes)
                 region2 = parse_region(region2, self._chromsizes)
-                i0, i1 = region_to_extent(
-                    grp, self._chromids, region1, self.binsize
-                )
-                j0, j1 = region_to_extent(
-                    grp, self._chromids, region2, self.binsize
-                )
+                i0, i1 = region_to_extent(grp, self._chromids, region1, self.binsize)
+                j0, j1 = region_to_extent(grp, self._chromids, region2, self.binsize)
                 return i0, i1, j0, j1
 
         return RangeSelector2D(field, _slice, _fetch, (self._info["nbins"],) * 2)
@@ -592,7 +588,9 @@ def annotate(pixels, bins, replace=False):
             lo = 0 if np.isnan(lo) else lo
             hi = 0 if np.isnan(hi) else hi
             if is_selector:
-                right1 = bins[lo:hi + bin1.dtype.type(1)].copy()  # slicing works like iloc
+                right1 = bins[
+                    lo : hi + bin1.dtype.type(1)
+                ].copy()  # slicing works like iloc
             else:
                 right1 = bins.loc[lo:hi].copy()
         elif is_selector:
@@ -601,8 +599,8 @@ def annotate(pixels, bins, replace=False):
         else:
             right1 = bins.copy()
             lo = 0
-        right1.columns = [f'{col}1' for col in right1.columns]
-        right1 = right1.iloc[pixels['bin1_id']-lo].reset_index(drop=True)
+        right1.columns = [f"{col}1" for col in right1.columns]
+        right1 = right1.iloc[pixels["bin1_id"] - lo].reset_index(drop=True)
     else:
         right1 = None
 
@@ -614,7 +612,9 @@ def annotate(pixels, bins, replace=False):
             lo = 0 if np.isnan(lo) else lo
             hi = 0 if np.isnan(hi) else hi
             if is_selector:
-                right2 = bins[lo:hi + bin2.dtype.type(1)].copy()  # slicing works like iloc
+                right2 = bins[
+                    lo : hi + bin2.dtype.type(1)
+                ].copy()  # slicing works like iloc
             else:
                 right2 = bins.loc[lo:hi].copy()
         elif is_selector:
@@ -623,13 +623,12 @@ def annotate(pixels, bins, replace=False):
         else:
             right2 = bins.copy()
             lo = 0
-        right2.columns = [f'{col}2' for col in right2.columns]
-        right2 = right2.iloc[pixels['bin2_id']-lo].reset_index(drop=True)
+        right2.columns = [f"{col}2" for col in right2.columns]
+        right2 = right2.iloc[pixels["bin2_id"] - lo].reset_index(drop=True)
     else:
         right2 = None
     index = pixels.index
-    pixels = pd.concat([pixels.reset_index(drop=True), right1, right2],
-                        axis=1)
+    pixels = pd.concat([pixels.reset_index(drop=True), right1, right2], axis=1)
     pixels.index = index
     # rearrange columns
     pixels = pixels[list(pixels.columns[ncols:]) + list(pixels.columns[:ncols])]
@@ -719,7 +718,7 @@ def matrix(
             + "calculate balancing weights or set balance=False."
         )
 
-    reader = CSRReader(h5['pixels'], h5['indexes/bin1_offset'][:])
+    reader = CSRReader(h5["pixels"], h5["indexes/bin1_offset"][:])
 
     if as_pixels:
         # The historical behavior for as_pixels is to return only explicitly stored

--- a/src/cooler/api.py
+++ b/src/cooler/api.py
@@ -594,7 +594,7 @@ def annotate(pixels, bins, replace=False):
 
     # Select bin annotations that correspond to the bin1 IDs in the pixels df
     if "bin1_id" in columns:
-        bin1 = pixels["bin1_id"].to_numpy().astype(int)
+        bin1 = pixels["bin1_id"].to_numpy().astype(int, copy=False, casting="safe")
         if len(bin1) == 0:
             min = max = 0
         elif len(bins) > len(pixels):
@@ -614,7 +614,7 @@ def annotate(pixels, bins, replace=False):
 
     # Select bin annotations that correspond to the bin2 IDs in the pixels df
     if "bin2_id" in columns:
-        bin2 = pixels["bin2_id"].to_numpy().astype(int)
+        bin2 = pixels["bin2_id"].to_numpy().astype(int, copy=False, casting="safe")
         if len(bin2) == 0:
             min = max = 0
         elif len(bins) > len(pixels):


### PR DESCRIPTION
Changed the annotate function to use indexing and concatenation instead of df.merge(). Makes it about 2x faster.