### PR TITLE
feat: Support custom contig sep characters in pairix index

### DIFF
--- a/src/cooler/cli/cload.py
+++ b/src/cooler/cli/cload.py
@@ -292,8 +292,24 @@ def tabix(
     default=2,
     show_default=True,
 )
+@click.option(
+    "--block-char",
+    help="Character separating contig names in the block names of the pairix "
+    "index.",
+    type=str,
+    default="|",
+    show_default=True,
+)
 def pairix(
-    bins, pairs_path, cool_path, metadata, assembly, nproc, zero_based, max_split
+    bins,
+    pairs_path,
+    cool_path,
+    metadata,
+    assembly,
+    nproc,
+    zero_based,
+    max_split,
+    block_char,
 ):
     """
     Bin a pairix-indexed contact list file.
@@ -326,6 +342,7 @@ def pairix(
             map=map_func,
             is_one_based=(not zero_based),
             n_chunks=max_split,
+            block_char=block_char,
         )
 
         create_cooler(

--- a/src/cooler/create/_ingest.py
+++ b/src/cooler/create/_ingest.py
@@ -824,7 +824,7 @@ class PairixAggregator(ContactBinner):
         blocknames = f.get_blocknames()
         if block_char not in blocknames[0]:
             raise ValueError(
-                f"The contig separator character `{block_char}` does not appear "
+                f"The contig separator character `{block_char}` does not "
                 f"appear in the first block name `{blocknames[0]}`. Please "
                 "specify the correct character as `block_char`."
             )

--- a/tests/test_create_ingest.py
+++ b/tests/test_create_ingest.py
@@ -17,7 +17,7 @@ from cooler.cli.cload import tabix as cload_tabix
 from cooler.cli.load import load
 
 pysam_missing = importlib.util.find_spec("pysam") is None
-pairix_missing = importlib.util.find_spec("pairix") is None
+pairix_missing = importlib.util.find_spec("pypairix") is None
 _pandas_major_version = int(pd.__version__.split(".")[0])
 
 tmp = tempfile.gettempdir()
@@ -246,6 +246,7 @@ def test_cload_pairix(bins_path, pairs_path, ref_path, nproc):
         nproc=nproc,
         zero_based=False,
         max_split=2,
+        block_char="|",
     )
     with h5py.File(testcool_path, "r") as f1, h5py.File(ref_path, "r") as f2:
         assert np.all(f1["pixels/bin1_id"][:] == f2["pixels/bin1_id"][:])
@@ -255,6 +256,21 @@ def test_cload_pairix(bins_path, pairs_path, ref_path, nproc):
         os.remove(testcool_path)
     except OSError:
         pass
+
+
+def test_cload_pairix_wrong_block_char():
+    with pytest.raises(ValueError):
+        cload_pairix.callback(
+            op.join(testdir, "data", "hg19.bins.2000kb.bed.gz"),
+            op.join(testdir, "data", "hg19.GM12878-MboI.pairs.subsample.blksrt.txt.gz"),
+            testcool_path,
+            metadata=None,
+            assembly="hg19",
+            nproc=1,
+            zero_based=False,
+            max_split=2,
+            block_char="?",
+        )
 
 
 @pytest.mark.skipif(

--- a/tests/test_create_ingest.py
+++ b/tests/test_create_ingest.py
@@ -258,6 +258,7 @@ def test_cload_pairix(bins_path, pairs_path, ref_path, nproc):
         pass
 
 
+@pytest.mark.skipif(pairix_missing, reason="pairix not installed")
 def test_cload_pairix_wrong_block_char():
     with pytest.raises(ValueError):
         cload_pairix.callback(


### PR DESCRIPTION
By default, the `|` character is used to delimit contig names in pairix index blocks, e.g. `chr1|chr1`, `chr1|chr2`, etc.

However, many FASTA sequence names contain pipes, which conflicts with this usage. Pairix supports creating an index with a different contig separator using `-w`, but this hasn't been supported in `cooler cload pairix`. See #234.

This PR lets the user provide a custom separator to `cooler cload pairix` via `--block-char` if it happens to be known or is discovered by the user (unfortunately, pypairix provides no way to determine this character dynamically) and will error if the separator is incorrect.