### PR TITLE
Fix annotate for chunked operations like in insulation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 readme = "README.md"
 
 dependencies = [
-    "numpy>=1.9",
+    "numpy>=1.9, <2",
     "scipy>=0.16",
     "pandas>1.5",
     "h5py>=2.5",

--- a/src/cooler/api.py
+++ b/src/cooler/api.py
@@ -661,16 +661,6 @@ def annotate(
     out.index = pixels.index
     return out
 
-    # Drop original bin IDs if not wanted
-    if replace:
-        cols_to_drop = [col for col in ("bin1_id", "bin2_id") if col in columns]
-        pixels = pixels.drop(cols_to_drop, axis=1)
-
-    # Concatenate bin annotations with pixels
-    out = pd.concat([*anns, pixels.reset_index(drop=True)], axis=1)
-    out.index = pixels.index
-    return out
-
 
 def matrix(
     h5: h5py.Group,

--- a/src/cooler/api.py
+++ b/src/cooler/api.py
@@ -631,7 +631,7 @@ def annotate(
             bmin, bmax = 0, None
         ann1 = _loc_slice(bins, bmin, bmax)
         anns.append(
-            ann1.iloc[bin1 - bmin]
+            ann1.loc[bin1]
             .rename(columns=lambda x: x + "1")
             .reset_index(drop=True)
         )
@@ -647,7 +647,7 @@ def annotate(
             bmin, bmax = 0, None
         ann2 = _loc_slice(bins, bmin, bmax)
         anns.append(
-            ann2.iloc[bin2 - bmin]
+            ann2.loc[bin2]
             .rename(columns=lambda x: x + "2")
             .reset_index(drop=True)
         )

--- a/src/cooler/core/__init__.py
+++ b/src/cooler/core/__init__.py
@@ -5,7 +5,7 @@ from ._rangequery import (
     region_to_extent,
     region_to_offset,
 )
-from ._selectors import RangeSelector1D, RangeSelector2D, _IndexingMixin
+from ._selectors import RangeSelector1D, RangeSelector2D, _IndexingMixin  # noqa
 from ._tableops import delete, get, put
 
 __all__ = [

--- a/src/cooler/core/__init__.py
+++ b/src/cooler/core/__init__.py
@@ -5,7 +5,7 @@ from ._rangequery import (
     region_to_extent,
     region_to_offset,
 )
-from ._selectors import RangeSelector1D, RangeSelector2D
+from ._selectors import RangeSelector1D, RangeSelector2D, _IndexingMixin
 from ._tableops import delete, get, put
 
 __all__ = [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -99,6 +99,21 @@ def test_annotate_with_partial_bins():
         assert out[col].notnull().all()
 
 
+def test_annotate_with_partial_bins_and_partial_pixels():
+    # Addresses a bug where annotating only certain pixels with a partial bin-table
+    # dataframe would lead to IndexError
+
+    clr = api.Cooler(op.join(datadir, "hg19.GM12878-MboI.matrix.2000kb.cool"))
+    pix = clr.matrix(as_pixels=True, balance=False).fetch("chr2:0-1000000")
+
+    bins_region = clr.bins().fetch("chr2:0-1000000")
+
+    out = api.annotate(pix, bins_region)
+
+    for col in ["chrom1", "start1", "end1", "chrom2", "start2", "end2"]:
+        assert out[col].notnull().all()
+
+
 def test_matrix():
     clr = api.Cooler(op.join(datadir, "yeast.10kb.cool"))
     region = ("chrI:100345-220254", "chrII:200789-813183")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,18 +100,25 @@ def test_annotate_with_partial_bins():
 
 
 def test_annotate_with_partial_bins_and_partial_pixels():
-    # Addresses a bug where annotating only certain pixels with a partial bin-table
-    # dataframe would lead to IndexError
+    # Addresses a bug where annotating only certain pixels with a partial
+    # bin-table dataframe would lead to IndexError
 
     clr = api.Cooler(op.join(datadir, "hg19.GM12878-MboI.matrix.2000kb.cool"))
-    pix = clr.matrix(as_pixels=True, balance=False).fetch("chr2:0-1000000")
+    region = "chr2:0-1000000"
 
-    bins_region = clr.bins().fetch("chr2:0-1000000")
+    pix = clr.matrix(as_pixels=True, balance=False).fetch(region)
 
+    # Use partial bin table
+    bins_region = clr.bins().fetch(region)
     out = api.annotate(pix, bins_region)
-
     for col in ["chrom1", "start1", "end1", "chrom2", "start2", "end2"]:
         assert out[col].notnull().all()
+
+    # Compare with full bin table as selector
+    pd.testing.assert_frame_equal(out, api.annotate(pix, clr.bins()))
+
+    # Compare with full bin table materialized
+    pd.testing.assert_frame_equal(out, api.annotate(pix, clr.bins()[:]))
 
 
 def test_matrix():


### PR DESCRIPTION
Simple solution with .loc instead of .iloc - probaly a bit slower, perhaps some arithmetic can fix the .iloc to behave correctly