### PR TITLE
Update to numpy 2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
         include:
           - os: windows-latest
             python-version: "3.12"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ "3.10", "3.11", "3.12" ]
+        python-version: [ "3,9", "3.10", "3.11", "3.12" ]
         include:
           - os: windows-latest
             python-version: "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 readme = "README.md"
 
 dependencies = [
-    "numpy>=1.9",
+    "numpy>=2.0",
     "scipy>=0.16",
     "pandas>1.5",
     "h5py>=2.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ all = [
     "ipytree>=0.2.2",
     "ipywidgets>=8.0.0",
     "matplotlib",
-    "pypairix; platform_system != 'Windows'",
+#    "pypairix; platform_system != 'Windows'", # doesn't compile, see 4dn-dcic/pairix#79
     "psutil",
     "pysam; platform_system != 'Windows'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "cooler"
 version = "0.10.2"
 description = "Sparse binary format for genomic interaction matrices."
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "BSD-3-Clause"}
 authors = [
   {name = "Nezar Abdennur", email = "nabdennur@gmail.com"},
@@ -29,7 +29,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -39,7 +38,7 @@ classifiers = [
 readme = "README.md"
 
 dependencies = [
-    "numpy>=2.0",
+    "numpy>=1.26,<3",
     "scipy>=0.16",
     "pandas>1.5",
     "h5py>=2.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 readme = "README.md"
 
 dependencies = [
-    "numpy>=1.9, <2",
+    "numpy>=1.9",
     "scipy>=0.16",
     "pandas>1.5",
     "h5py>=2.5",

--- a/src/cooler/_reduce.py
+++ b/src/cooler/_reduce.py
@@ -4,7 +4,8 @@ import math
 import warnings
 from bisect import bisect_right
 from collections import OrderedDict, defaultdict
-from typing import Any, Iterator, Literal
+from collections.abc import Iterator
+from typing import Any, Literal
 
 import h5py
 import multiprocess as mp

--- a/src/cooler/_typing.py
+++ b/src/cooler/_typing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable, Dict, Iterable, Optional, Tuple, TypeVar, Union
+from collections.abc import Iterable
+from typing import Callable, Optional, TypeVar, Union
 
 import numpy as np
 import pandas as pd
@@ -8,8 +9,8 @@ import pandas as pd
 T = TypeVar('T')
 U = TypeVar('U')
 MapFunctor = Callable[[Callable[[T], U], Iterable[T]], Iterable[U]]
-GenomicRangeSpecifier = Union[str , Tuple[str, Optional[int], Optional[int]]]
-GenomicRangeTuple = Tuple[str, int, int]
-Tabular = Union[pd.DataFrame, Dict[str, np.ndarray]]
+GenomicRangeSpecifier = Union[str , tuple[str, Optional[int], Optional[int]]]
+GenomicRangeTuple = tuple[str, int, int]
+Tabular = Union[pd.DataFrame, dict[str, np.ndarray]]
 
 __all__ = ["MapFunctor", "GenomicRangeSpecifier", "GenomicRangeTuple", "Tabular"]

--- a/src/cooler/core/_rangequery.py
+++ b/src/cooler/core/_rangequery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Iterator
+from collections.abc import Iterator
+from typing import Any, Callable
 
 import h5py
 import numpy as np

--- a/src/cooler/core/_selectors.py
+++ b/src/cooler/core/_selectors.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Callable, List, Optional, Tuple, Union, overload
+from typing import Any, Callable, Optional, Union, overload
 
 import pandas as pd
 
-ColumnsArg = Optional[Union[str, List[str]]]
-GenomicRangeArg = Optional[Union[str, Tuple[str, Optional[int], Optional[int]]]]
+ColumnsArg = Optional[Union[str, list[str]]]
+GenomicRangeArg = Optional[Union[str, tuple[str, Optional[int], Optional[int]]]]
 FieldArg = Optional[str]
 
 

--- a/src/cooler/core/_tableops.py
+++ b/src/cooler/core/_tableops.py
@@ -102,7 +102,7 @@ def get(
             data[field] = pd.Categorical.from_codes(
                 dset[lo:hi], sorted(dt, key=dt.__getitem__), ordered=True
             )
-        elif dset.dtype.type == np.string_:
+        elif dset.dtype.type == np.bytes_:
             data[field] = dset[lo:hi].astype("U")
         else:
             data[field] = dset[lo:hi]

--- a/src/cooler/create/_create.py
+++ b/src/cooler/create/_create.py
@@ -5,8 +5,9 @@ import os.path as op
 import posixpath
 import tempfile
 import warnings
+from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Iterable
+from typing import Any
 
 import h5py
 import numpy as np

--- a/src/cooler/create/_ingest.py
+++ b/src/cooler/create/_ingest.py
@@ -112,8 +112,8 @@ def _sanitize_records(
         return chunk
 
     # Find positional anchor columns, convert to zero-based if needed
-    anchor1 = np.array(chunk[anchor_field + suffixes[0]])
-    anchor2 = np.array(chunk[anchor_field + suffixes[1]])
+    anchor1 = chunk[anchor_field + suffixes[0]].to_numpy(copy=True)
+    anchor2 = chunk[anchor_field + suffixes[1]].to_numpy(copy=True)
     if is_one_based:
         anchor1 -= 1
         anchor2 -= 1

--- a/src/cooler/create/_ingest.py
+++ b/src/cooler/create/_ingest.py
@@ -12,8 +12,9 @@ import itertools
 import warnings
 from bisect import bisect_left
 from collections import Counter, OrderedDict
+from collections.abc import Iterator
 from functools import partial
-from typing import Any, Callable, Iterator
+from typing import Any, Callable
 
 import h5py
 import numpy as np

--- a/src/cooler/parallel.py
+++ b/src/cooler/parallel.py
@@ -5,8 +5,9 @@ coolers.
 """
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator, Sequence
 from functools import partial, reduce
-from typing import Any, Callable, Iterable, Iterator, Sequence
+from typing import Any, Callable
 
 from multiprocess import Lock
 

--- a/src/cooler/util.py
+++ b/src/cooler/util.py
@@ -627,7 +627,7 @@ def infer_meta(x, index=None):  # pragma: no cover
         "m": np.timedelta64(1),
         "S": np.str_("foo"),
         "a": np.str_("foo"),
-        "U": np.unicode_("foo"),
+        "U": np.str_("foo"),
         "O": "foo",
     }
 

--- a/src/cooler/util.py
+++ b/src/cooler/util.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import os
 import re
 from collections import OrderedDict, defaultdict
+from collections.abc import Generator, Iterable, Iterator
 from contextlib import contextmanager
-from typing import IO, Any, Generator, Iterable, Iterator
+from typing import IO, Any
 
 import h5py
 import numpy as np


### PR DESCRIPTION
Hi all,
updated the codebase to work with numpy 2.x .
Also had a look at the CI – the current CI failure seems to be caused by pypairix breaking on compile, commenting the dependency out makes it run. Have submitted an issue there and propose adding it again when that is fixed.
Currently, some test cases in `test_cli_ingest.py` and `test_create_ingest.py` are returning different values than stored in `tests/data`.
Not sure what's causing that, as the numpy update shouldn't change behaviour in this way. Might be the missing pypairix dependency, or an earlier change that wasn't noticed due to the general CI failure?
In a local pipeline using cooler I don't see any changes, so I think this should be fine to merge anyways, though it would be nice to get CI passing.
Cheers and happy winter holidays,
Leon
