### PR TITLE
Set multiprocessing fork method explicitly through context

### DIFF
--- a/src/cooler/_reduce.py
+++ b/src/cooler/_reduce.py
@@ -722,7 +722,8 @@ def coarsen_cooler(
     try:
         # Note: fork before opening to prevent inconsistent global HDF5 state
         if nproc > 1:
-            pool = mp.Pool(nproc)
+            ctx = mp.get_context("fork")
+            pool = ctx.Pool(nproc)
             kwargs.setdefault("lock", lock)
 
         iterator = CoolerCoarsener(

--- a/src/cooler/cli/balance.py
+++ b/src/cooler/cli/balance.py
@@ -2,9 +2,9 @@ import sys
 
 import click
 import h5py
+import multiprocess as mp
 import numpy as np
 import pandas as pd
-from multiprocess import Pool
 
 from .._balance import balance_cooler
 from ..api import Cooler
@@ -236,7 +236,8 @@ def balance(
 
     try:
         if nproc > 1:
-            pool = Pool(nproc)
+            ctx = mp.get_context("fork")
+            pool = ctx.Pool(nproc)
             map_ = pool.imap_unordered
         else:
             map_ = map

--- a/src/cooler/cli/cload.py
+++ b/src/cooler/cli/cload.py
@@ -2,11 +2,11 @@ import sys
 
 import click
 import h5py
+import multiprocess as mp
 import numpy as np
 import pandas as pd
 import simplejson as json
 from cytoolz import compose
-from multiprocess import Pool
 
 from ..create import (
     HDF5Aggregator,
@@ -230,7 +230,8 @@ def tabix(
     try:
         map_func = map
         if nproc > 1:
-            pool = Pool(nproc)
+            ctx = mp.get_context("fork")
+            pool = ctx.Pool(nproc)
             logger.info(f"Using {nproc} cores")
             map_func = pool.imap
 
@@ -331,7 +332,8 @@ def pairix(
     try:
         map_func = map
         if nproc > 1:
-            pool = Pool(nproc)
+            ctx = mp.get_context("fork")
+            pool = ctx.Pool(nproc)
             logger.info(f"Using {nproc} cores")
             map_func = pool.imap
 


### PR DESCRIPTION
The default start method for multiprocessing will change from "fork" to "spawn" on all platforms: https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods

This PR uses contexts to keep the current fork behavior until we decide to migrate to spawn or refactor further. cc @mimakaev 