### PR TITLE
replace external "simplejson" backport from Py3 to Py3 with plain "json" module

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,4 +8,3 @@ multiprocess
 click
 asciitree
 pyyaml
-simplejson

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
     "pyfaidx",
     "asciitree",
     "pyyaml",
-    "simplejson",
 ]
 
 [project.optional-dependencies]

--- a/src/cooler/api.py
+++ b/src/cooler/api.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import json
 import os
 
 import h5py
 import numpy as np
 import pandas as pd
-import simplejson as json
 from pandas.api.types import is_integer_dtype
 from scipy.sparse import coo_matrix
 

--- a/src/cooler/cli/cload.py
+++ b/src/cooler/cli/cload.py
@@ -1,10 +1,10 @@
+import json
 import sys
 
 import click
 import h5py
 import numpy as np
 import pandas as pd
-import simplejson as json
 from cytoolz import compose
 from multiprocess import Pool
 

--- a/src/cooler/cli/info.py
+++ b/src/cooler/cli/info.py
@@ -1,7 +1,7 @@
+import json
 import sys
 
 import click
-import simplejson as json
 
 from ..api import Cooler
 from ..util import attrs_to_jsonable

--- a/src/cooler/cli/load.py
+++ b/src/cooler/cli/load.py
@@ -1,9 +1,9 @@
+import json
 import sys
 
 import click
 import numpy as np
 import pandas as pd
-import simplejson as json
 
 from ..create import (
     BIN_DTYPE,

--- a/src/cooler/create/_create.py
+++ b/src/cooler/create/_create.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import os.path as op
 import posixpath
@@ -12,7 +13,6 @@ from typing import Any
 import h5py
 import numpy as np
 import pandas as pd
-import simplejson as json
 
 from .._logging import get_logger
 from .._typing import Tabular

--- a/src/cooler/fileops.py
+++ b/src/cooler/fileops.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 import os
 
 # from textwrap import dedent
+import json
 import warnings
 from collections.abc import Callable
 from datetime import datetime
 from numbers import Number
 from typing import Any, Literal
-
-import simplejson as json
 
 try:
     from simplejson import JSONDecodeError

--- a/tests/test_cli_ingest.py
+++ b/tests/test_cli_ingest.py
@@ -1,4 +1,5 @@
 # from io import StringIO
+import json
 import os.path as op
 import tempfile
 from glob import glob
@@ -6,7 +7,6 @@ from glob import glob
 import numpy as np
 import pandas as pd
 import pytest
-import simplejson as json
 
 # from _common import cooler_cmp
 from click.testing import CliRunner


### PR DESCRIPTION
The simplejson module was really usefull .... back then