### PR TITLE
make parse_region 1-based

### DIFF
--- a/src/cooler/util.py
+++ b/src/cooler/util.py
@@ -82,7 +82,7 @@ def parse_region_string(s: str) -> tuple[str, int | None, int | None]:
     Parameters
     ----------
     s : str
-        UCSC-style string, e.g. "chr5:10,100,000-30,000,000". Ensembl and FASTA
+        UCSC-style string, e.g. "chr5:10,100,001-30,000,000". Ensembl and FASTA
         style sequence names are allowed. End coordinate must be greater than
         or equal to start.
 
@@ -115,6 +115,9 @@ def parse_region_string(s: str) -> tuple[str, int | None, int | None]:
         typ, token = next(tokens, (None, None))
         _check_token(typ, token, ["COORD"])
         start = parse_humanized(token)
+        if start == 0:
+            raise ValueError("Ranges are 1-based and hence cannot start at 0")
+        start -= 1
 
         typ, token = next(tokens, (None, None))
         _check_token(typ, token, ["HYPHEN"])
@@ -145,8 +148,7 @@ def parse_region(
     chromsizes: dict | pd.Series | None = None
 ) -> GenomicRangeTuple:
     """
-    Genomic regions are represented as half-open intervals (0-based starts,
-    1-based ends) along the length coordinate of a contig/scaffold/chromosome.
+    Genomic regions are represented as half-open intervals along the length coordinate of a contig/scaffold/chromosome.
 
     Parameters
     ----------

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -68,13 +68,13 @@ def test_atoi():
 def test_parse_region_string():
     # UCSC-style names
     assert util.parse_region_string("chr21") == ("chr21", None, None)
-    assert util.parse_region_string("chr21:1000-2000") == ("chr21", 1000, 2000)
-    assert util.parse_region_string("chr21:1,000-2,000") == ("chr21", 1000, 2000)
+    assert util.parse_region_string("chr21:1001-2000") == ("chr21", 1000, 2000)
+    assert util.parse_region_string("chr21:1,001-2,000") == ("chr21", 1000, 2000)
 
     # Ensembl style names
     assert util.parse_region_string("6") == ("6", None, None)
-    assert util.parse_region_string("6:1000-2000") == ("6", 1000, 2000)
-    assert util.parse_region_string("6:1,000-2,000") == ("6", 1000, 2000)
+    assert util.parse_region_string("6:1001-2000") == ("6", 1000, 2000)
+    assert util.parse_region_string("6:1,001-2,000") == ("6", 1000, 2000)
 
     # FASTA style names
     assert util.parse_region_string("gb|accession|locus") == (
@@ -82,12 +82,12 @@ def test_parse_region_string():
         None,
         None,
     )
-    assert util.parse_region_string("gb|accession|locus:1000-2000") == (
+    assert util.parse_region_string("gb|accession|locus:1001-2000") == (
         "gb|accession|locus",
         1000,
         2000,
     )
-    assert util.parse_region_string("gb|accession|locus:1,000-2,000") == (
+    assert util.parse_region_string("gb|accession|locus:1,001-2,000") == (
         "gb|accession|locus",
         1000,
         2000,
@@ -100,23 +100,24 @@ def test_parse_region_string():
         None,
     )
     assert util.parse_region_string("GL000207.1") == ("GL000207.1", None, None)
-    assert util.parse_region_string("GL000207.1:1000-2000") == (
+    assert util.parse_region_string("GL000207.1:1001-2000") == (
         "GL000207.1",
         1000,
         2000,
     )
 
     # Trailing dash
-    assert util.parse_region_string("chr21:1000-") == ("chr21", 1000, None)
+    assert util.parse_region_string("chr21:1001-") == ("chr21", 1000, None)
 
     # Humanized units
-    assert util.parse_region_string("6:1kb-2kb") == ("6", 1000, 2000)
-    assert util.parse_region_string("6:1k-2000") == ("6", 1000, 2000)
-    assert util.parse_region_string("6:1kb-2M") == ("6", 1000, 2000000)
-    assert util.parse_region_string("6:1Gb-") == ("6", 1000000000, None)
+    assert util.parse_region_string("6:1kb-2kb") == ("6", 999, 2000)
+    assert util.parse_region_string("6:1k-2000") == ("6", 999, 2000)
+    assert util.parse_region_string("6:1kb-2M") == ("6", 999, 2000000)
+    assert util.parse_region_string("6:1Gb-") == ("6", 1000000000 - 1, None)
 
     # Bad inputs
     for region in [
+        "chr1:0-100", # coords start at 1
         "chr1:2,000-1,000",  # reverse selection
         "chr1::1000-2000",  # more than one colon
         "chr1:1kb-2kDa",  # unknown unit kDa
@@ -132,13 +133,13 @@ def test_parse_region_string():
 def test_parse_region():
     chromsizes = util.read_chromsizes(op.join(datadir, "toy.chrom.sizes"))
     assert util.parse_region(("chr1", 0, 10)) == ("chr1", 0, 10)
-    assert util.parse_region("chr1:0-10") == ("chr1", 0, 10)
-    assert util.parse_region("chr1:0-", chromsizes) == ("chr1", 0, chromsizes["chr1"])
+    assert util.parse_region("chr1:1-10") == ("chr1", 0, 10)
+    assert util.parse_region("chr1:1-", chromsizes) == ("chr1", 0, chromsizes["chr1"])
 
     # Don't accept undefined end unless chromsizes exists
     # NOTE: parse_region_string works here
     with pytest.raises(ValueError):
-        util.parse_region("chr1:0-")
+        util.parse_region("chr1:1-")
 
     # catch end < start in non-string case
     with pytest.raises(ValueError):


### PR DESCRIPTION
`parse_region_string()` turns a human readable string into a tuple. The former should be one-based while the latter is zero-based. https://genome-blog.gi.ucsc.edu/blog/2016/12/12/the-ucsc-genome-browser-coordinate-counting-systems/

I didn't run the tests as I couldn't get the environment to work, sorry.