### PR TITLE
451: Avoid Unnecessary Re-Creation of Bins in scool to Prevent File Bloat

### DIFF
--- a/src/cooler/create/_create.py
+++ b/src/cooler/create/_create.py
@@ -1239,13 +1239,36 @@ def create_scool(
     n_chroms = len(chroms)
     n_bins = len(bins)
 
-    # Create root group
+    # Create root group (updated)
+    bins_identical = False
     with h5py.File(file_path, mode) as f:
         logger.info(f'Creating cooler at "{file_path}::{group_path}"')
-        if group_path == "/":
-            for name in ["chroms", "bins"]:
-                if name in f:
-                    del f[name]
+        if group_path in f:
+            grp = f[group_path]
+            # Check if a bins group already exists
+            if "bins" in grp:
+                # Read the existing bins datasets
+                existing_chrom = grp["bins/chrom"][()]
+                existing_start = grp["bins/start"][()]
+                existing_end = grp["bins/end"][()]
+                # If stored as bytes, decode to string
+                if existing_chrom.dtype.kind == "S":
+                    existing_chrom = np.char.decode(existing_chrom, "utf-8")
+                existing_bins = pd.DataFrame({
+                    "chrom": existing_chrom,
+                    "start": existing_start,
+                    "end": existing_end,
+                }).reset_index(drop=True)
+                new_bins = bins[["chrom", "start", "end"]].reset_index(drop=True)
+                if existing_bins.equals(new_bins):
+                    logger.info("Existing bins are identical; skipping bins re-creation.")
+                    bins_identical = True
+                else:
+                    logger.info("Bins differ; re-creating bins group.")
+                    del grp["bins"]
+            # Always re-create chroms for consistency (or add a similar check if desired)
+            if "chroms" in grp:
+                del grp["chroms"]
         else:
             try:
                 f.create_group(group_path)
@@ -1253,20 +1276,22 @@ def create_scool(
                 del f[group_path]
                 f.create_group(group_path)
 
+    # Write chroms and bins
     with h5py.File(file_path, "r+") as f:
         h5 = f[group_path]
-
         logger.info("Writing chroms")
         grp = h5.create_group("chroms")
         write_chroms(grp, chroms, h5opts)
+        if not bins_identical:
+            logger.info("Writing bins")
+            grp = h5.create_group("bins")
+            write_bins(grp, bins, chroms["name"], h5opts)
+        else:
+            logger.info("Skipping writing bins since they are identical.")
 
-        logger.info("Writing bins")
-        grp = h5.create_group("bins")
-        write_bins(grp, bins, chroms["name"], h5opts)
-
+    # Write info
     with h5py.File(file_path, "r+") as f:
         h5 = f[group_path]
-
         logger.info("Writing info")
         info = {}
         info["bin-type"] = "fixed" if binsize is not None else "variable"
@@ -1282,11 +1307,7 @@ def create_scool(
 
     # Append single cells
     for key in cell_names:
-        if "/" in key:
-            cell_name = key.split("/")[-1]
-        else:
-            cell_name = key
-
+        cell_name = key.split("/")[-1] if "/" in key else key
         create(
             cool_uri + "::/cells/" + cell_name,
             bins_dict[key],


### PR DESCRIPTION
This patch addresses an issue in the current scool file creation workflow where, during append operations, the bins group is always deleted and re-created—even when the bins data (i.e., the "chrom", "start", and "end" columns) hasn’t changed. Over time, this behavior leads to file bloat due to HDF5’s inability to reclaim deleted space automatically.

What’s Changed:

Conditional Bins Update:
The patch introduces a check that compares the existing bins in the file with the new bins data. If they match, the bins group is left intact, avoiding unnecessary deletion and re-creation.

Consistent Chromosome Data:
The chroms group is always updated to ensure consistency, while the bins group is only rewritten when there is an actual difference in the underlying data.

Why This Matters:

Space Efficiency:
By skipping redundant writes when the bins are identical, we prevent the accumulation of dead space and reduce the need for costly file repacking operations (e.g., using h5repack).

Improved Performance:
Avoiding unnecessary I/O operations helps maintain a leaner file size and can lead to faster append operations over multiple iterations.

Testing:

The patch was tested locally by creating an initial scool file, appending cells with unchanged bins (which showed minimal file size increase), and then appending with modified bins (which resulted in a larger file increase as expected).
Additional Notes:

HDF5 Limitations:
Even with this patch, HDF5 will not automatically reclaim space from deleted datasets. For existing files with accumulated dead space, tools like h5repack are still recommended.

Future Enhancements:
A longer-term improvement might involve accepting a single shared bins DataFrame with per-cell iterators, reducing memory usage and further streamlining the workflow.

Please review the changes and let me know if there are any questions or further improvements needed.