### PR TITLE
Avoid double counting self-interactions with `--ignore-diags 0`

### DIFF
--- a/src/cooler/_balance.py
+++ b/src/cooler/_balance.py
@@ -63,7 +63,8 @@ def _timesouterproduct(vec, chunk, data):
 def _marginalize(chunk, data):
     n = len(chunk["bins"]["chrom"])
     pixels = chunk["pixels"]
-    marg = np.bincount(pixels["bin1_id"], weights=data, minlength=n) + np.bincount(
+    not_self = pixels["bin1_id"] != pixels["bin2_id"]  # Only include self-interactions once.
+    marg = np.bincount(pixels["bin1_id"] * not_self, weights=data, minlength=n) + np.bincount(
         pixels["bin2_id"], weights=data, minlength=n
     )
     return marg


### PR DESCRIPTION
Hello,

Thanks for the awesome code!

I have a use case where I need to balance without ignoring any diagonals (i.e. using `--ignore-diags 0`). I found that when doing this, the self-interactions (the main diagonal of the matrix) are counted twice. This is because `cooler._balance._marginalize` sums together both bin_ids, and for self-interactions by definition the bin_ids are the same.

I believe this double-counting is unintentional. This likely hasn’t been widely noticed since `--ignore-diags 0` is not the standard use case. This pull request contains a minor fix to only count the self-interactions once. Please let me know if there is something I'm missing and counting the self-interactions twice is indeed desired!

Best,
Joe