### PR TITLE
docs: clarify cload pairs compression support

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -153,7 +153,9 @@ cooler cload pairs
 
     Bin any text file or stream of pairs.
 
-    Pairs data need not be sorted. Accepts compressed files.
+    Pairs data need not be sorted. For file paths, compression is inferred from the
+    filename extension using formats supported by pandas.read_csv. LZ4 is not
+    supported.
     To pipe input from stdin, set PAIRS_PATH to '-'.
 
 

--- a/src/cooler/cli/cload.py
+++ b/src/cooler/cli/cload.py
@@ -504,7 +504,9 @@ def pairs(
     """
     Bin any text file or stream of pairs.
 
-    Pairs data need not be sorted. Accepts compressed files.
+    Pairs data need not be sorted. For file paths, compression is inferred from the
+    filename extension using formats supported by pandas.read_csv. LZ4 is not
+    supported.
     To pipe input from stdin, set PAIRS_PATH to '-'.
 
     {}


### PR DESCRIPTION
## Summary

- clarify that compression for path inputs is inferred from the filename extension
- limit the documented formats to those supported by `pandas.read_csv` and explicitly note that LZ4 is unsupported
- keep the generated CLI reference synchronized with the command docstring

Closes #410

## Validation

- `git diff --check`
- parsed `cload.py` with Python's AST
- verified the `cload pairs` description is identical in the source docstring and `docs/cli.rst`

I could not run the full documentation build because the available package environment could not resolve a complete compatible `cooler` dependency set. This is a documentation-only change and does not alter runtime behavior.

This contribution was prepared with AI-assisted tooling. I reviewed the final diff and verified it against the implementation path and the maintainer's clarification in #410.
